### PR TITLE
Fix problem with callback for workflow changes

### DIFF
--- a/CoarNotifyReviewOfferPlugin.inc.php
+++ b/CoarNotifyReviewOfferPlugin.inc.php
@@ -207,7 +207,6 @@ class CoarNotifyReviewOfferPlugin extends GenericPlugin {
         $smarty->assign([
             'submissionType' => $this->getSubmissionType(),
             'reviewServiceList' => $this->getReviewServiceList(),
-            'submission' => json_encode($submission),
             'originHomeUrl' => $this->getSetting($this->getCurrentContextId(), 'originHomeUrl'),
             'originInboxUrl' => $this->getSetting($this->getCurrentContextId(), 'originInboxUrl'),
             'actorName' => $user->getFullName(),
@@ -215,11 +214,6 @@ class CoarNotifyReviewOfferPlugin extends GenericPlugin {
             'isPublished' => $this->isSubmissionPublished($submission),
             'doi' => $this->getDoi($submission),
             'reviewOfferPreferences' => $this->getReviewOfferPreferences($submission->getData('id')),
-        ]);
-
-        $submission = $smarty->get_template_vars('submission');
-        $smarty->assign([
-            'submissionId' => $submission->getId(),
         ]);
 
         $output .= sprintf(

--- a/templates/coarNotifyReviewOffer.tpl
+++ b/templates/coarNotifyReviewOffer.tpl
@@ -53,7 +53,7 @@
             <p>{translate key="plugins.generic.coarNotifyReviewOffer.prePubDescriptionPartTwo"}</p>
 
             <div id="reviewOfferPreferences">
-                {capture assign=reviewOfferPrefsGridUrl}{url router=$smarty.const.ROUTE_COMPONENT component="plugins.generic.coarNotifyReviewOffer.controllers.grid.CoarReviewOfferGridHandler" op="fetchGrid" submissionId=$submissionId escape=false}{/capture}
+                {capture assign=reviewOfferPrefsGridUrl}{url router=$smarty.const.ROUTE_COMPONENT component="plugins.generic.coarNotifyReviewOffer.controllers.grid.CoarReviewOfferGridHandler" op="fetchGrid" submissionId=$submission->getId() escape=false}{/capture}
                 {load_url_in_div id="reviewOfferPrefsGridContainer"|uniqid url=$reviewOfferPrefsGridUrl}
             </div>
         {/if}


### PR DESCRIPTION
Greetings!

We noticed an error in the callback for the workflow page, which affects other plugins which add their tabs to this page.

The callback replaced the submission object with a JSON encoding of it. This resulted in errors for the others plugins executed after it, leading to the break of the workflow page.