### PR TITLE
Re-adds function to create notifications for review offer sending

### DIFF
--- a/CoarNotifyReviewOfferPlugin.inc.php
+++ b/CoarNotifyReviewOfferPlugin.inc.php
@@ -63,6 +63,17 @@ class CoarNotifyReviewOfferPlugin extends GenericPlugin {
         return 'This plugin notifies target review services when a submission has been successful and is ready for pre-reviews.';
     }
 
+    private function notification($type, $message)
+    {
+        import('classes.notification.NotificationManager');
+        $notificationMgr = new NotificationManager();
+        $notificationMgr->createTrivialNotification(
+            Application::get()->getRequest()->getUser()->getId(),
+            $type,
+            ['contents' => __($message)]
+        );
+    }
+
     private function getAuthorId($user): string {
         $orcid = $user->getOrcid();
         return ($orcid != "") ? $orcid : "mailto:{$user->getEmail()}";
@@ -348,12 +359,12 @@ class CoarNotifyReviewOfferPlugin extends GenericPlugin {
 
                 $this->notification(
                     NOTIFICATION_TYPE_SUCCESS,
-                    'Review Offer sent',
+                    'plugins.generic.coarNotifyReviewOffer.notification.reviewOfferSending.success',
                 );
             } catch (Exception $e) {
                 $this->notification(
                     NOTIFICATION_TYPE_ERROR,
-                    'Review Offer failed to send',
+                    'plugins.generic.coarNotifyReviewOffer.notification.reviewOfferSending.fail',
                 );
             }
         }

--- a/locale/en_US/locale.po
+++ b/locale/en_US/locale.po
@@ -96,3 +96,9 @@ msgstr "To automatically offer your preprint for peer review after posting to an
 
 msgid "plugins.generic.coarNotifyReviewOffer.prePubDescriptionPartTwo"
 msgstr "A request will then be sent to the target service via the COAR Notify protocol once your preprint has been posted. You can update this choice at any point before posting."
+
+msgid "plugins.generic.coarNotifyReviewOffer.notification.reviewOfferSending.success"
+msgstr "Review Offer sent"
+
+msgid "plugins.generic.coarNotifyReviewOffer.notification.reviewOfferSending.fail"
+msgstr "Review Offer failed to send"

--- a/locale/es_ES/locale.po
+++ b/locale/es_ES/locale.po
@@ -96,3 +96,9 @@ msgstr "Para ofrecer automáticamente su preprint para la evaluación por pares 
 
 msgid "plugins.generic.coarNotifyReviewOffer.prePubDescriptionPartTwo"
 msgstr "A continuación, se enviará una solicitud al servicio de destino a través del protocolo COAR Notify una vez que se haya publicado su preprint. Puede actualizar esta opción en cualquier momento antes de la publicación."
+
+msgid "plugins.generic.coarNotifyReviewOffer.notification.reviewOfferSending.success"
+msgstr "Opciones de evaluación enviadas"
+
+msgid "plugins.generic.coarNotifyReviewOffer.notification.reviewOfferSending.fail"
+msgstr "No se pudieron enviar las opciones de evaluación"

--- a/locale/pt_BR/locale.po
+++ b/locale/pt_BR/locale.po
@@ -96,3 +96,9 @@ msgstr "Para oferecer automaticamente o seu preprint para avaliação por pares 
 
 msgid "plugins.generic.coarNotifyReviewOffer.prePubDescriptionPartTwo"
 msgstr "Uma solicitação será enviada ao serviço de destino por meio do protocolo COAR Notify assim que o seu preprint for postado. Você pode atualizar essa opção a qualquer momento antes da postagem."
+
+msgid "plugins.generic.coarNotifyReviewOffer.notification.reviewOfferSending.success"
+msgstr "Opções de avaliação enviadas"
+
+msgid "plugins.generic.coarNotifyReviewOffer.notification.reviewOfferSending.fail"
+msgstr "Falha no envio das opções de avaliação"


### PR DESCRIPTION
Hi! I noticed there's a missing function to create notifications when review offers are sent. This leads to an error in submission publishing/posting, so I added back the notification function.

I also took the opportunity to add locale keys to these notifications.