### PR TITLE
Fixes cross-origin request problem

### DIFF
--- a/CoarNotifyReviewOfferPlugin.php
+++ b/CoarNotifyReviewOfferPlugin.php
@@ -31,6 +31,7 @@ use APP\plugins\generic\coarNotifyReviewOffer\classes\migration\CoarNotifyReview
 use APP\plugins\generic\coarNotifyReviewOffer\classes\ReviewOfferPreference;
 use APP\plugins\generic\coarNotifyReviewOffer\classes\ReviewOfferPreferenceDAO;
 use APP\plugins\generic\coarNotifyReviewOffer\controllers\grid\CoarReviewOfferGridHandler;
+use \APP\plugins\generic\coarNotifyReviewOffer\controllers\CoarNotifyProxyHandler;
 
 class CoarNotifyReviewOfferPlugin extends GenericPlugin {
     /** @var array Lazy loaded review service list */
@@ -52,7 +53,7 @@ class CoarNotifyReviewOfferPlugin extends GenericPlugin {
             Hook::add('TemplateManager::display', [$this, 'addToSubmissionWizardSteps']);
             Hook::add('Template::SubmissionWizard::Section', [$this, 'addToSubmissionWizardTemplate']);
 
-            Hook::add('LoadComponentHandler', [$this, 'setupGridHandler']);
+            Hook::add('LoadComponentHandler', [$this, 'setupHandlers']);
             Hook::add('Publication::publish', [$this, 'sendNotificationsOnPublish'], Hook::SEQUENCE_CORE);
         }
 
@@ -301,7 +302,7 @@ class CoarNotifyReviewOfferPlugin extends GenericPlugin {
      * @param $hookName string The name of the hook being invoked
      * @param $args array The parameters to the invoked hook
      */
-    function setupGridHandler($hookName, $params) {
+    function setupHandlers($hookName, $params) {
         $component = &$params[0];
         $componentInstance = &$params[2];
 
@@ -310,6 +311,13 @@ class CoarNotifyReviewOfferPlugin extends GenericPlugin {
             $componentInstance->setPlugin($this);
             return true;
         }
+
+        if ($component == 'plugins.generic.coarNotifyReviewOffer.controllers.CoarNotifyProxyHandler') {
+            $componentInstance = new CoarNotifyProxyHandler();
+            $componentInstance->setPlugin($this);
+            return true;
+        }
+
         return false;
     }
 

--- a/CoarNotifyReviewOfferPlugin.php
+++ b/CoarNotifyReviewOfferPlugin.php
@@ -80,7 +80,7 @@ class CoarNotifyReviewOfferPlugin extends GenericPlugin {
         return __('plugins.generic.coarNotifyReviewOffer.plugin.description');
     }
 
-    private function notification($type, $message) {
+    public function notification($type, $message) {
         $notificationMgr = new NotificationManager();
         $notificationMgr->createTrivialNotification(
             Application::get()->getRequest()->getUser()->getId(),

--- a/controllers/CoarNotifyProxyHandler.php
+++ b/controllers/CoarNotifyProxyHandler.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * @file plugins/generic/coarNotifyReviewOffer/controllers/CoarNotifyProxyHandler.php
+ *
+ * Copyright (c) --
+ * Distributed under the GNU GPL v3. For full terms see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt
+ *
+ * @class CoarNotifyProxyHandler
+ * @ingroup plugins_generic_coarNotifyReviewOffer
+ * @brief Handler class for COAR Notify proxy requests to avoid CORS issues.
+ */
+
+namespace APP\plugins\generic\coarNotifyReviewOffer\controllers;
+
+use APP\handler\Handler;
+use PKP\core\JSONMessage;
+use PKP\security\authorization\ContextAccessPolicy;
+use PKP\security\Role;
+use APP\core\Application;
+
+class CoarNotifyProxyHandler extends Handler {
+    private $plugin;
+
+    public function __construct() {
+        parent::__construct();
+        $this->addRoleAssignment(
+            [Role::ROLE_ID_MANAGER, Role::ROLE_ID_SUB_EDITOR, Role::ROLE_ID_ASSISTANT, Role::ROLE_ID_AUTHOR],
+            ['sendNotification']
+        );
+    }
+
+    public function authorize($request, &$args, $roleAssignments) {
+        $this->addPolicy(new ContextAccessPolicy($request, $roleAssignments));
+        return parent::authorize($request, $args, $roleAssignments);
+    }
+
+    public function setPlugin($plugin) {
+        $this->plugin = $plugin;
+    }
+
+    public function sendNotification($args, $request) {
+        if (!$request->checkCSRF()) return new JSONMessage(false);
+        
+        return;
+    }
+}
+
+?>

--- a/controllers/CoarNotifyProxyHandler.php
+++ b/controllers/CoarNotifyProxyHandler.php
@@ -17,6 +17,7 @@ use PKP\core\JSONMessage;
 use PKP\security\authorization\ContextAccessPolicy;
 use PKP\security\Role;
 use APP\core\Application;
+use APP\notification\Notification;
 
 class CoarNotifyProxyHandler extends Handler {
     private $plugin;
@@ -39,9 +40,27 @@ class CoarNotifyProxyHandler extends Handler {
     }
 
     public function sendNotification($args, $request) {
-        if (!$request->checkCSRF()) return new JSONMessage(false);
-        
-        return;
+        $notification = json_decode(file_get_contents('php://input'), true);
+        $targetUrl = $notification['target']['inbox'];
+
+        if (empty($targetUrl)) {
+            return new JSONMessage(false);
+        }
+
+        try {
+            $this->plugin->sendHttpPostRequest($targetUrl, $notification);
+            $this->plugin->notification(
+                Notification::NOTIFICATION_TYPE_SUCCESS,
+                'plugins.generic.coarNotifyReviewOffer.notification.reviewOfferSending.success',
+            );
+            return new JSONMessage(true);
+        } catch (\Exception $e) {
+            $this->plugin->notification(
+                Notification::NOTIFICATION_TYPE_ERROR,
+                'plugins.generic.coarNotifyReviewOffer.notification.reviewOfferSending.fail',
+            );
+            return new JSONMessage(false);
+        }
     }
 }
 

--- a/js/coar-notify.js
+++ b/js/coar-notify.js
@@ -49,10 +49,7 @@ function sendNotificationHandler(
         headers: {
             'Content-Type': 'application/json',
         },
-        body: JSON.stringify({
-            targetInboxUrl: targetInboxUrl,
-            payload: payload
-        }),
+        body: JSON.stringify(payload),
     })
         .then(response => response)
         .then(data => {

--- a/js/coar-notify.js
+++ b/js/coar-notify.js
@@ -1,4 +1,5 @@
 function sendNotificationHandler(
+    sendNotificationUrl,
     originInboxUrl,
     originHomeUrl,
     targetInboxUrl,
@@ -43,12 +44,15 @@ function sendNotificationHandler(
         ]
     };
 
-    fetch(targetInboxUrl, {
+    fetch(sendNotificationUrl, {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json',
         },
-        body: JSON.stringify(payload),
+        body: JSON.stringify({
+            targetInboxUrl: targetInboxUrl,
+            payload: payload
+        }),
     })
         .then(response => response)
         .then(data => {

--- a/templates/coarNotifyReviewOffer.tpl
+++ b/templates/coarNotifyReviewOffer.tpl
@@ -20,6 +20,7 @@
 
         <h3>{translate key="plugins.generic.coarNotifyReviewOffer.services"}</h3>
         <div>
+            {capture assign=sendNotificationUrl}{url router=$smarty.const.ROUTE_COMPONENT component="plugins.generic.coarNotifyReviewOffer.controllers.CoarNotifyProxyHandler" op="sendNotification" escape=false}{/capture}
             {foreach from=$reviewServiceList key=targetHomeUrl item=targetInboxUrl name=reviewServiceList}
                 <div class="reviewBlock">
                     <h4 class="reviewServiceHomeUrl">{$targetHomeUrl}</h4>
@@ -27,6 +28,7 @@
                             id="{$smarty.foreach.reviewServiceList.index}-send-button"
                             class="askForReviewButton"
                             onclick="sendNotificationHandler(
+                                    '{$sendNotificationUrl}',
                                     '{$originInboxUrl}',
                                     '{$originHomeUrl}',
                                     '{$targetInboxUrl}',


### PR DESCRIPTION
When sending the review offer after posting, the browser console shown a message saying the request was blocked due to it being a cross-origin request. For this reason, I changed it so the backend now does the request sending the notification.